### PR TITLE
更新依赖项版本并升级包版本

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "candle-resnet"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-image = "0.25.1"
+image = "0.25.2"
 [dependencies.candle-nn]
-version = "0.4.1"
+version = "0.7.2"
 # git="ssh://git@github.com/huggingface/candle.git"
 # branch = "main"
 [dependencies.candle-core]
-version = "0.4.1"
+version = "0.7.2"
 # git = "ssh://git@github.com/huggingface/candle.git"
 # branch = "main"


### PR DESCRIPTION
- 将 candle-resnet 包版本从 0.1.0 升级到 0.1.1
- 更新 image 依赖版本从 0.25.1 升级到 0.25.2
- 将 candle-nn 和 candle-core 依赖版本从 0.4.1 升级到 0.7.2